### PR TITLE
update start script to include options for using nodemon separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "--",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon src",
+    "start": "node src",
+    "start-watch": "nodemon src",
     "eslint": "gulp eslint",
     "precommit": "npm run eslint"
   },


### PR DESCRIPTION
# Changelog
- Revert start script to how it was previously since nodemon is not installed when we create a docker image and the app would not be able to start.
- Add a new start script to run the application in watch mode using nodemon