### PR TITLE
add endpoint for token validation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -54,6 +54,14 @@ const constants = {
       },
     },
   },
+  jwtResponse: {
+    error: {
+      // same error messages thrown by jwt.verify when token is invalid
+      JWT_MALFORMED: { ERROR: 'jwt malformed', MSG: 'The token received is malformed' },
+      JWT_INVALID_SIGNATURE: { ERROR: 'invalid signature', MSG: 'The token received has an invalid signature' },
+      JWT_EXPIRED: { ERROR: 'jwt expired', MSG: 'The token received has expired' },
+    },
+  },
   errorCodes: {
     AUTH__EMAIL_DOES_NOT_EXIST: 'AUTH__EMAIL_DOES_NOT_EXIST',
     AUTH__PASSWORD_DOES_NOT_MATCH: 'AUTH__PASSWORD_DOES_NOT_MATCH',


### PR DESCRIPTION
# Description

This PR implements the follow:
1 - Add a route to validate if a token sent from the front-end is still valid. If the token is valid, the decoded token will be sent with a http status code 200 as response. If either the token is malformed, expired or the signature is invalid, a status code of 401 (unathorized) will be sent to as response. 

# Test
1 - Install dependencies `npm i`. 
2 - Set the required environment variable `JWT_SECRET` by creating a `.env` file in the main directory and set your secret in that file ie. `JWT_SECRET=HELLO`.
3 - run the app using `npm run start`. If you want to skip step 2, you can set the env with `JWT_SECRET=HELLO npm run start`.

- Login with your credentials (if you do not remember your credential, you can use my credential from the sample command:
    -  method: POST http://localhost:8000/users/login
    -  body parameters:
        - `email` type: string
        - `password` type: string

Sample command:
`curl -d "email=antonio@gmail.coml&password=password" -X POST http://localhost:8000/users/login`

The response should be :

```
{"statusCode":200,"statusText":"SUCCESS","data":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFudG9uaW9AZ21haWwuY29tbCIsImlhdCI6MTU2Nzk2Mzg2OSwiZXhwIjoxNTY4MDUwMjY5fQ.VQBz0Ci5ywZr5CRZQG1SfUwtdWPeamC3HbW5z_rEGJY"}
```
Note that the token was sent in the data field.

Now we can proceed to test our new endpoint!

- Check if the token is valid by using our new endpoint:
    -  method: GET http://localhost:8000/users/validate-token/:token
    -  body parameters: none
:token will be the same token that you received from the login response. In this case for me, :token will be `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFudG9uaW9AZ21haWwuY29tbCIsImlhdCI6MTU2Nzk2Mzg2OSwiZXhwIjoxNTY4MDUwMjY5fQ.VQBz0Ci5ywZr5CRZQG1SfUwtdWPeamC3HbW5z_rEGJY`

Sample command:
`curl -X GET http://localhost:8000/users/validate-token/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFudG9uaW9AZ21haWwuY29tbCIsImlhdCI6MTU2Nzk2Mzg2OSwiZXhwIjoxNTY4MDUwMjY5fQ.VQBz0Ci5ywZr5CRZQG1SfUwtdWPeamC3HbW5z_rEGJY`

The response should be: 

```
{"statusCode":200,"statusText":"SUCCESS","data":{"id":"antonio@gmail.coml","iat":1567963869,"exp":1568050269}}
```

To test for if the token is malformed, we will send a malformed token:
`curl -X GET http://localhost:8000/users/validate-token/malformed-token`

The response should be:

```
{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received is malformed"}

```

To test for if the token is expired, we will send an expired token (I created this token with a 1s exp time to test this part):

`curl -X GET http://localhost:8000/users/validate-token/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6InRlc3QiLCJpYXQiOjE1Njc5NjIxMTYsImV4cCI6MTU2Nzk2MjExN30.YZ5x1b6xRYYsK3Dn2bCCLjSgXTlHJ6C7oJdnWZYWhBM`

The response should be:

```
{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received has expired"}

```

To test for if the token has an invalid signature, we will send a token that has an invalid signature:

`curl -X GET http://localhost:8000/users/validate-token/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6InRlc3QiLCJpYXQiOjE1Njc5NjIxMTYsImV4cCI6MTU2Nzk2MjExN30.YZ5x1b6xRYYsK3Dn2bCCLjSgXTlHJ6C7oJdnWZYWhBMs`

The response should be:

```
{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received has an invalid signature"}
```

# Next to do
Front end implementation which will make use of this endpoint to check if the current token stored in the local storage is valid or not.