### PR TITLE
update-response-status-for-invalid-token

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -54,6 +54,14 @@ const constants = {
       },
     },
   },
+  jwtResponse: {
+    error: {
+      // same error messages thrown by jwt.verify when token is invalid
+      JWT_MALFORMED: { ERROR: 'jwt malformed', MSG: 'The token received is malformed' },
+      JWT_INVALID_SIGNATURE: { ERROR: 'invalid signature', MSG: 'The token received has an invalid signature' },
+      JWT_EXPIRED: { ERROR: 'jwt expired', MSG: 'The token received has expired' },
+    },
+  },
   errorCodes: {
     AUTH__EMAIL_DOES_NOT_EXIST: 'AUTH__EMAIL_DOES_NOT_EXIST',
     AUTH__PASSWORD_DOES_NOT_MATCH: 'AUTH__PASSWORD_DOES_NOT_MATCH',

--- a/src/constants.js
+++ b/src/constants.js
@@ -60,6 +60,7 @@ const constants = {
       JWT_MALFORMED: { ERROR: 'jwt malformed', MSG: 'The token received is malformed' },
       JWT_INVALID_SIGNATURE: { ERROR: 'invalid signature', MSG: 'The token received has an invalid signature' },
       JWT_EXPIRED: { ERROR: 'jwt expired', MSG: 'The token received has expired' },
+      JWT_NOT_PROVIDED: { ERROR: 'jwt must be provided', MSG: 'Token was not provided' },
     },
   },
   errorCodes: {

--- a/src/utils/middlewares/get-decoded-token.js
+++ b/src/utils/middlewares/get-decoded-token.js
@@ -5,9 +5,18 @@ const constants = require('../../constants');
 
 const {
   error: {
-    forbidden,
+    unauthorized,
+    serverError,
   },
 } = constants.httpResponse;
+
+const {
+  error: {
+    JWT_MALFORMED,
+    JWT_INVALID_SIGNATURE,
+    JWT_EXPIRED,
+  },
+} = constants.jwtResponse;
 
 
 const getDecodedToken = (req, res, next) => {
@@ -17,7 +26,21 @@ const getDecodedToken = (req, res, next) => {
     req.decodedToken = decodedToken;
     next();
   } catch (error) {
-    responseHandler.handleError(res, forbidden.CODE);
+    const { message } = error;
+
+    switch (message) {
+      case JWT_MALFORMED.ERROR:
+        responseHandler.handleError(res, unauthorized.CODE, JWT_MALFORMED.MSG);
+        break;
+      case JWT_EXPIRED.ERROR:
+        responseHandler.handleError(res, unauthorized.CODE, JWT_EXPIRED.MSG);
+        break;
+      case JWT_INVALID_SIGNATURE.ERROR:
+        responseHandler.handleError(res, unauthorized.CODE, JWT_INVALID_SIGNATURE.MSG);
+        break;
+      default:
+        responseHandler.handleError(res, serverError.CODE);
+    }
   }
 };
 

--- a/src/utils/middlewares/get-decoded-token.js
+++ b/src/utils/middlewares/get-decoded-token.js
@@ -15,6 +15,7 @@ const {
     JWT_MALFORMED,
     JWT_INVALID_SIGNATURE,
     JWT_EXPIRED,
+    JWT_NOT_PROVIDED,
   },
 } = constants.jwtResponse;
 
@@ -29,6 +30,9 @@ const getDecodedToken = (req, res, next) => {
     const { message } = error;
 
     switch (message) {
+      case JWT_NOT_PROVIDED.ERROR:
+        responseHandler.handleError(res, unauthorized.CODE, JWT_NOT_PROVIDED.MSG);
+        break;
       case JWT_MALFORMED.ERROR:
         responseHandler.handleError(res, unauthorized.CODE, JWT_MALFORMED.MSG);
         break;


### PR DESCRIPTION
# Description

This PR implements the follow:
1 - Update the response status code when the token is invalid. Currently its returning 403 (forbidden) and it should be 401. I've also added custom messages for each type of invalid tokens.

# Test
1 - Install dependencies 
2 - Set the required environment variable `JWT_SECRET` by creating a `.env` file in the main directory and set your secret in that file ie. `JWT_SECRET=HELLO`.
3 - run the app using `npm run start`. If you want to skip step 2, you can set the env with `JWT_SECRET=HELLO npm run start`.


Send a GET request to get the user cart with an invalid token:
-  method: GET http://localhost:8000/carts
-  body parameters: none
-  request header must contain "Authorization: Bearer token"

For this PR, we dont need valid tokens since we are testing for invalid tokens.

Sample commands:
- No token provided:
`curl http://localhost:8000/carts`
Response status should be:
`{"statusCode":401,"statusText":"UNAUTHORIZED","message":"Token was not provided"}`

- Malformed token:
`curl -H "Authorization: Bearer malformed-token" -X GET http://localhost:8000/carts`
Response status should be:
`{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received is malformed"}`

- Expired token:
`curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6InRlc3QiLCJpYXQiOjE1Njc5NjIxMTYsImV4cCI6MTU2Nzk2MjExN30.YZ5x1b6xRYYsK3Dn2bCCLjSgXTlHJ6C7oJdnWZYWhBM" -X GET http://localhost:8000/carts`
Response status should be:
`{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received has expired"}`

- Invalid signature:
`curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6InRlc3QiLCJpYXQiOjE1Njc5NjIxMTYsImV4cCI6MTU2Nzk2MjExN30.YZ5x1b6xRYYsK3Dn2bCCLjSgXTlHJ6C7oJdnWZYWhBMs" -X GET http://localhost:8000/carts`
Response status should be :
`{"statusCode":401,"statusText":"UNAUTHORIZED","message":"The token received has an invalid signature"}`

# To do after
Remove token on the front end when we receive a 401.